### PR TITLE
Fix GitHub Actions Workflow Permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,17 +4,27 @@ on:
   pull_request:
     branches: ["*"]
 
+# Define permissions at workflow level
+permissions:
+  contents: read
+  pull-requests: read
+
 jobs:
   test:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
       - name: Use Node.js
         uses: actions/setup-node@v4
         with:
           node-version: "18"
           cache: "npm"
+
       - name: Install dependencies
         run: npm ci
+
       - name: Run linting
         run: npm run lint

--- a/.github/workflows/deploy-development.yml
+++ b/.github/workflows/deploy-development.yml
@@ -5,20 +5,33 @@ on:
     branches:
       - development
 
+# Define permissions at workflow level
+permissions:
+  contents: read
+  deployments: write
+  statuses: write
+
 jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          # Ensure we have the full repository history
+          fetch-depth: 0
+
       - name: Use Node.js
         uses: actions/setup-node@v4
         with:
           node-version: "18"
           cache: "npm"
+
       - name: Install dependencies
         run: npm ci
+
       - name: Run linting
         run: npm run lint
+
       - name: Deploy to Vercel (Development)
         uses: amondnet/vercel-action@v25
         with:
@@ -27,3 +40,4 @@ jobs:
           vercel-project-id: ${{ secrets.VERCEL_PROJECT_ID }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
           vercel-args: "--prod"
+          working-directory: ./

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -6,21 +6,34 @@ on:
       - main
   workflow_dispatch:
 
+# Define permissions at workflow level
+permissions:
+  contents: read
+  deployments: write
+  statuses: write
+
 jobs:
   deploy:
     runs-on: ubuntu-latest
     environment: production
     steps:
       - uses: actions/checkout@v4
+        with:
+          # Ensure we have the full repository history
+          fetch-depth: 0
+
       - name: Use Node.js
         uses: actions/setup-node@v4
         with:
           node-version: "18"
           cache: "npm"
+
       - name: Install dependencies
         run: npm ci
+
       - name: Run linting
         run: npm run lint
+
       - name: Deploy to Vercel (Production)
         uses: amondnet/vercel-action@v25
         with:
@@ -29,3 +42,4 @@ jobs:
           vercel-project-id: ${{ secrets.VERCEL_PROJECT_ID }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
           vercel-args: "--prod"
+          working-directory: ./

--- a/DEPLOYMENT_WORKFLOW.md
+++ b/DEPLOYMENT_WORKFLOW.md
@@ -115,6 +115,33 @@ If a deployment fails:
 4. Push the fix to the appropriate branch
 5. The deployment will automatically retry
 
+## GitHub Actions Permissions
+
+Our GitHub Actions workflows have specific permissions configured to ensure they can perform necessary deployment operations:
+
+### Production Workflow
+The production deployment workflow has these permissions:
+- `contents: read` - For reading repository content
+- `deployments: write` - For creating deployments
+- `statuses: write` - For updating commit statuses
+
+### Development Workflow
+The development deployment workflow has similar permissions:
+- `contents: read` - For reading repository content
+- `deployments: write` - For creating deployments 
+- `statuses: write` - For updating commit statuses
+
+### CI Workflow
+The CI workflow used for pull requests has:
+- `contents: read` - For reading repository content
+- `pull-requests: read` - For accessing pull request information
+
+If deployment issues occur with "Resource not accessible by integration" errors, check:
+1. Workflow permissions in the YAML files
+2. Repository secrets configuration
+3. Vercel token permissions and expiration
+4. GitHub Actions permissions settings in the repository settings
+
 ## Environment Variables
 
 - Environment variables are managed in the Vercel dashboard


### PR DESCRIPTION
## Description
This PR addresses the "Resource not accessible by integration" error in our GitHub Actions workflows.

## Changes Included
- Added workflow-level permissions to all GitHub Actions workflows:
  - `contents: read`, `deployments: write`, `statuses: write` for deployment workflows
  - `contents: read`, `pull-requests: read` for CI workflow
- Enhanced checkout configuration with `fetch-depth: 0` for full history access
- Added `working-directory: ./` parameter to Vercel action
- Updated DEPLOYMENT_WORKFLOW.md with permissions documentation

## Type of Change
- [x] Bug fix
- [ ] New feature
- [x] Documentation update

Fixes issue DEVOPS-002