### PR TITLE
Fix: Add permissions for GitHub Actions comment integration

### DIFF
--- a/.github/workflows/deploy-development.yml
+++ b/.github/workflows/deploy-development.yml
@@ -10,6 +10,8 @@ permissions:
   contents: read
   deployments: write
   statuses: write
+  issues: write
+  pull-requests: write
 
 jobs:
   deploy:

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -11,6 +11,8 @@ permissions:
   contents: read
   deployments: write
   statuses: write
+  issues: write
+  pull-requests: write
 
 jobs:
   deploy:

--- a/DEPLOYMENT_WORKFLOW.md
+++ b/DEPLOYMENT_WORKFLOW.md
@@ -124,12 +124,16 @@ The production deployment workflow has these permissions:
 - `contents: read` - For reading repository content
 - `deployments: write` - For creating deployments
 - `statuses: write` - For updating commit statuses
+- `issues: write` - For commenting on issues
+- `pull-requests: write` - For commenting on PRs with deployment information
 
 ### Development Workflow
 The development deployment workflow has similar permissions:
 - `contents: read` - For reading repository content
 - `deployments: write` - For creating deployments 
 - `statuses: write` - For updating commit statuses
+- `issues: write` - For commenting on issues
+- `pull-requests: write` - For commenting on PRs with deployment information
 
 ### CI Workflow
 The CI workflow used for pull requests has:


### PR DESCRIPTION
## Description
This PR addresses the "Resource not accessible by integration" error in our GitHub Actions workflows when posting comments about Vercel deployments.

## Changes Included
- Added `issues: write` permission to deployment workflows for commenting on issues
- Added `pull-requests: write` permission to deployment workflows for commenting on PRs
- Updated documentation in DEPLOYMENT_WORKFLOW.md to reflect these new permissions

## Type of Change
- [x] Bug fix
- [ ] New feature
- [x] Documentation update

## How Has This Been Tested?
Verification will occur after the PR is merged when a new deployment is triggered.

## Fixes
Resolves issue DEVOPS-003 - "Resource not accessible by integration" error in GitHub Actions workflows.