### PR TITLE
Fix: Update Supabase configuration to handle Vercel environment variables

### DIFF
--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -1,11 +1,7 @@
 import { createClient } from '@supabase/supabase-js';
 
-// Get environment variables from Vite
-const supabaseUrl = import.meta.env.VITE_SUPABASE_URL;
-const supabaseAnonKey = import.meta.env.VITE_SUPABASE_ANON_KEY;
+// Get environment from Vite or detect it based on hostname
 const explicitEnv = import.meta.env.VITE_ENV;
-
-// Improved environment detection logic
 const environment = explicitEnv || 
   (window.location.hostname.includes('vercel.app') && !window.location.hostname.includes('-preview') ? 
   'production' : 'development');
@@ -16,10 +12,33 @@ console.log(`- Hostname: ${window.location.hostname}`);
 console.log(`- Explicit VITE_ENV: ${explicitEnv || '(not set)'}`);
 console.log(`- Detected environment: ${environment}`);
 
+// Get environment variables based on detected environment
+// Try Vercel's environment-prefixed variables first, then fall back to Vite variables for local development
+let supabaseUrl: string;
+let supabaseAnonKey: string;
+
+if (environment === 'production') {
+  // For production, use PRODUCTION_* variables from Vercel or fallback to VITE_* variables
+  supabaseUrl = import.meta.env.PRODUCTION_SUPABASE_URL || import.meta.env.VITE_SUPABASE_URL;
+  supabaseAnonKey = import.meta.env.PRODUCTION_SUPABASE_ANON_KEY || import.meta.env.VITE_SUPABASE_ANON_KEY;
+} else {
+  // For development, use DEVELOPMENT_* variables from Vercel or fallback to VITE_* variables
+  supabaseUrl = import.meta.env.DEVELOPMENT_SUPABASE_URL || import.meta.env.VITE_SUPABASE_URL;
+  supabaseAnonKey = import.meta.env.DEVELOPMENT_SUPABASE_ANON_KEY || import.meta.env.VITE_SUPABASE_ANON_KEY;
+}
+
+// Validate environment variables are present
 if (!supabaseUrl || !supabaseAnonKey) {
   console.error(`Environment variables missing for ${environment} environment`);
-  console.error(`VITE_SUPABASE_URL: ${supabaseUrl ? 'Set' : 'Missing'}`);
-  console.error(`VITE_SUPABASE_ANON_KEY: ${supabaseAnonKey ? 'Set' : 'Missing'}`);
+  
+  if (environment === 'production') {
+    console.error(`PRODUCTION_SUPABASE_URL or VITE_SUPABASE_URL: ${supabaseUrl ? 'Set' : 'Missing'}`);
+    console.error(`PRODUCTION_SUPABASE_ANON_KEY or VITE_SUPABASE_ANON_KEY: ${supabaseAnonKey ? 'Set' : 'Missing'}`);
+  } else {
+    console.error(`DEVELOPMENT_SUPABASE_URL or VITE_SUPABASE_URL: ${supabaseUrl ? 'Set' : 'Missing'}`);
+    console.error(`DEVELOPMENT_SUPABASE_ANON_KEY or VITE_SUPABASE_ANON_KEY: ${supabaseAnonKey ? 'Set' : 'Missing'}`);
+  }
+  
   throw new Error(`Missing Supabase environment variables for ${environment} environment`);
 }
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,11 +1,28 @@
-import { defineConfig } from 'vite'
+import { defineConfig, loadEnv } from 'vite'
 import react from '@vitejs/plugin-react'
 
 // https://vite.dev/config/
-export default defineConfig({
-  plugins: [react()],
-  server: {
-    host: true, // Expose to all network interfaces
-    port: 5173,
-  },
+export default defineConfig(({ mode }) => {
+  // Load env file based on `mode` in the current directory
+  const env = loadEnv(mode, process.cwd(), '')
+  
+  // Expose Vercel environment variables to the client
+  const envWithProcessPrefix = Object.entries(env).reduce(
+    (acc, [key, val]) => {
+      // Forward all variables to the client
+      // Including PRODUCTION_* and DEVELOPMENT_* variables
+      acc[`import.meta.env.${key}`] = JSON.stringify(val)
+      return acc
+    },
+    {}
+  )
+  
+  return {
+    plugins: [react()],
+    server: {
+      host: true, // Expose to all network interfaces
+      port: 5173,
+    },
+    define: envWithProcessPrefix,
+  }
 })


### PR DESCRIPTION
## Description

This PR fixes the environment variable issue that's causing the production deployment to fail with "Missing Supabase environment variables" errors.

### Problem
The application is looking for `VITE_SUPABASE_URL` and `VITE_SUPABASE_ANON_KEY` variables, but our Vercel setup uses `PRODUCTION_SUPABASE_URL` and `PRODUCTION_SUPABASE_ANON_KEY` (for production) and `DEVELOPMENT_SUPABASE_URL` and `DEVELOPMENT_SUPABASE_ANON_KEY` (for development).

### Changes Made

1. **Updated `src/lib/supabase.ts`**:
   - Modified to detect the current environment and use the correct variable names
   - Added logic to check for both Vercel's environment-prefixed variables (`PRODUCTION_*` or `DEVELOPMENT_*`) and fall back to `VITE_*` variables for local development
   - Improved error messages to show which specific variables are missing

2. **Updated `vite.config.ts`**:
   - Added support for exposing Vercel's environment variables to the client
   - Configured Vite to pass through all environment variables, including `PRODUCTION_*` and `DEVELOPMENT_*` prefixed ones

### Testing
- This change ensures that the application can run in all environments:
  - Local development (using `.env` with `VITE_*` variables)
  - Vercel production (using `PRODUCTION_*` variables)
  - Vercel preview deployments (using `DEVELOPMENT_*` variables)

## Type of Change
- [x] Bug fix

This PR should be merged to `main` first, followed by a similar PR to `development` to ensure consistency across branches.