### PR TITLE
Fix: Add proper TypeScript typings to vite.config.ts

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -8,13 +8,13 @@ export default defineConfig(({ mode }) => {
   
   // Expose Vercel environment variables to the client
   const envWithProcessPrefix = Object.entries(env).reduce(
-    (acc, [key, val]) => {
+    (acc: Record<string, string>, [key, val]) => {
       // Forward all variables to the client
       // Including PRODUCTION_* and DEVELOPMENT_* variables
       acc[`import.meta.env.${key}`] = JSON.stringify(val)
       return acc
     },
-    {}
+    {} as Record<string, string>
   )
   
   return {


### PR DESCRIPTION
## Description

This PR fixes the TypeScript error in `vite.config.ts` that was causing the build to fail:

```
vite.config.ts(14,7): error TS7053: Element implicitly has an 'any' type because expression of type '`import.meta.env.${string}`' can't be used to index type '{}'.
```

### Changes Made

- Added proper type annotations to the accumulator in the `reduce` function
- Used `Record<string, string>` to explicitly type the accumulator object
- Added type casting to the initial empty object

### Testing

- These changes fix the TypeScript error while maintaining the same functionality
- The build process should now complete successfully

## Type of Change
- [x] Bug fix

Note: A similar PR (#19) has been created for the `main` branch.